### PR TITLE
Fix ingredient collision and UI click issues + add debug visuals

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -35,6 +35,12 @@ click={
 ]
 }
 
+[debug]
+
+shapes/collision/shape_color=Color(0, 0.6, 0.7, 0.42)
+shapes/collision/contact_color=Color(1, 0.2, 0.1, 0.8)
+shapes/collision/draw_2d_outlines=true
+
 [rendering]
 
 textures/canvas_textures/default_texture_filter=0

--- a/rooms/Kitchen.tscn
+++ b/rooms/Kitchen.tscn
@@ -119,6 +119,10 @@ script = ExtResource("2_puzzle")
 [node name="Ingredients" type="Node2D" parent="Puzzle"]
 
 [node name="Flour" type="Area2D" parent="Puzzle/Ingredients"]
+collision_layer = 2
+collision_mask = 1
+monitorable = true
+monitoring = true
 position = Vector2(850, 500)
 script = ExtResource("3_interactive")
 interaction_prompt = "Collect Flour"
@@ -144,6 +148,10 @@ text = "Flour"
 horizontal_alignment = 1
 
 [node name="Water" type="Area2D" parent="Puzzle/Ingredients"]
+collision_layer = 2
+collision_mask = 1
+monitorable = true
+monitoring = true
 position = Vector2(950, 500)
 script = ExtResource("3_interactive")
 interaction_prompt = "Collect Water"
@@ -169,6 +177,10 @@ text = "Water"
 horizontal_alignment = 1
 
 [node name="Sugar" type="Area2D" parent="Puzzle/Ingredients"]
+collision_layer = 2
+collision_mask = 1
+monitorable = true
+monitoring = true
 position = Vector2(1050, 500)
 script = ExtResource("3_interactive")
 interaction_prompt = "Collect Sugar"
@@ -194,6 +206,10 @@ text = "Sugar"
 horizontal_alignment = 1
 
 [node name="StoveInteractive" type="Area2D" parent="Puzzle"]
+collision_layer = 2
+collision_mask = 1
+monitorable = true
+monitoring = true
 position = Vector2(275, 525)
 script = ExtResource("3_interactive")
 interaction_prompt = "Cook Recipe"

--- a/scripts/Game.gd
+++ b/scripts/Game.gd
@@ -71,8 +71,8 @@ func load_room(room_name: String):
 		update_ui()
 		print("Loaded room: ", room_name)
 
-func _input(event):
-	"""Handle tap-to-move input"""
+func _unhandled_input(event):
+	"""Handle tap-to-move input (only if not handled by UI)"""
 	if event is InputEventMouseButton and event.pressed and event.button_index == MOUSE_BUTTON_LEFT:
 		if current_character:
 			# Get click position in world space


### PR DESCRIPTION
Round 2 of bug fixes based on continued testing:

1. FIXED: Ingredient Collision Blocking Movement Problem: Area2D collision shapes were blocking character movement Solution: Set proper collision layers on all interactive objects
   - collision_layer = 2 (ingredients on layer 2, not layer 1 with walls)
   - collision_mask = 1 (detect character on layer 1)
   - monitorable = true, monitoring = true
   - Now character can walk THROUGH ingredients to collect them
   - Applied to: Flour, Water, Sugar, StoveInteractive

2. FIXED: UI Buttons Still Passing Clicks Through Problem: _input() receives events BEFORE UI can handle them Solution: Changed _input() to _unhandled_input() in Game.gd
   - _unhandled_input only fires if UI didn't consume the event
   - This is the proper Godot way to handle game input vs UI input
   - Now clicking UI buttons does NOT move character

3. ADDED: Visual Collision Debug Outlines Problem: Hard to see where collision boundaries are Solution: Enabled debug collision shape rendering
   - Added [debug] section to project.godot
   - shapes/collision/draw_2d_outlines = true
   - Collision shapes now show as cyan/blue outlines
   - Makes it easy to see walls, props, and interactive areas
   - Can be disabled later for release build

Technical Details:
- Collision Layer 1: Walls, floors, props, character
- Collision Layer 2: Interactive objects (ingredients, items)
- Layer 2 objects detect Layer 1 but don't block it
- Proper event handling: UI -> Unhandled -> Game

Ready for testing round 3!